### PR TITLE
Fix the missing "...\roslyn\csc.exe" file during a build process

### DIFF
--- a/SandboxSite/SandboxSite.csproj
+++ b/SandboxSite/SandboxSite.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\Targets\Kentico.DotNetCompilerPlatform.Fix.targets"/>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Targets/Kentico.DotNetCompilerPlatform.Fix.targets
+++ b/Targets/Kentico.DotNetCompilerPlatform.Fix.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Fix missing RoslynToolPath property.
+       This happens only for the first build when the project is opened for the very first time and NuGet packages are restored. -->
+  <Target Name="FixMissingRoslynToolPathProperty" BeforeTargets="CopyFilesToOutputDirectory" Condition=" '$(RoslynToolPath)' == ''">
+    <PropertyGroup>
+      <RoslynToolPath>$(MSBuildThisFileDirectory)..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\tools\roslynlatest</RoslynToolPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- Re-populate the RoslynCompilerFiles after the RoslynToolPath property is set correctly -->
+      <RoslynCompilerFiles Include="$(RoslynToolPath)\*">
+        <Link>roslyn\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      </RoslynCompilerFiles>      
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Targets/Kentico.EmbeddedViews.targets
+++ b/Targets/Kentico.EmbeddedViews.targets
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Kentico.DotNetCompilerPlatform.Fix.targets"/>
+  <!-- Register all available Razor views in the assembly attribute and store it in a C# file -->
   <Target Name="BeforeBuild" Condition="'$(DeployOnBuild)' != 'true'">
     <ItemGroup>
       <ViewFiles Include="Views\**\*.cshtml" />
@@ -10,16 +12,24 @@
         %40"')")]
       </EmbeddedInfo>
     </PropertyGroup>
-	<MakeDir Directories="$(IntermediateOutputPath)"/>
+    <MakeDir Directories="$(IntermediateOutputPath)"/>
     <WriteLinesToFile File="$(IntermediateOutputPath)\ViewsPathsGenerated.cs" Lines="$(EmbeddedInfo)" Overwrite="true" Encoding="Utf-8" />
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)\ViewsPathsGenerated.cs" />
     </ItemGroup>
   </Target>
-  <Target Name="AfterBuild" Condition="'$(DeployOnBuild)' != 'true'">
+  <!-- Compile Razor views -->
+  <Target Name="AfterBuild" DependsOnTargets="FixMissingILRepackProperty" Condition="'$(DeployOnBuild)' != 'true'">
     <AspNetCompiler LogStandardErrorAsError="true" VirtualPath="/" PhysicalPath="$(MSBuildProjectDirectory)" TargetPath="$(IntermediateOutputPath)\Precompiled" Force="true" Debug="false" Updateable="false" Clean="true" />
     <Exec LogStandardErrorAsError="true" Command="$(ILRepack) /noRepackRes /parallel /wildcards /out:$(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).dll $(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).dll $(IntermediateOutputPath)\Precompiled\bin\App_Web_*.dll" />
     <Copy SourceFiles="$(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).dll" DestinationFolder="$(MSBuildProjectDirectory)\..\SandboxSite\bin\" />
     <Copy SourceFiles="$(IntermediateOutputPath)\Precompiled\bin\$(AssemblyName).pdb" DestinationFolder="$(MSBuildProjectDirectory)\..\SandboxSite\bin\" />
+  </Target>
+  <!-- Fix missing ILRepack property.
+       This happens only for the first build when the project is opened for the very first time and NuGet packages are restored. -->
+  <Target Name="FixMissingILRepackProperty" Condition=" '$(ILRepack)' == ''">
+    <PropertyGroup>
+      <ILRepack>$(MSBuildThisFileDirectory)..\packages\ILRepack.2.0.17\tools\ILRepack.exe</ILRepack>
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
### Motivation
The first build of this solution could end up with an error stating that roslyn/csc.exe file is missing in the MyCompany.Components.Views/bin folder

### How to test
Check that the fist and succeeding builds are successful. Try to open/close Visual Studio 