### PR TITLE
MAE-95 Ignore Kentico resx files in *.Views projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,9 @@ packages/
 
 # Ignore Nuget packages Kentico content files
 # kentico.languagepack.english
-MyCompany.*/CMSResources/*
+/*.Views/CMSResources/*
 SandboxSite/CMSResources/*
+
 # kentico.aspnet.mvc
 SandboxSite/App_Data/Global/Resources/Kentico.*
 


### PR DESCRIPTION
### Motivation

Prevent Git from listing .resx files brought by Kentico.LanguagePack.English package as untracked changes in *.Views projects.

